### PR TITLE
Ensure gwrite processes/outputs layers in the same order that vpype does

### DIFF
--- a/vpype_gcode/gwrite.py
+++ b/vpype_gcode/gwrite.py
@@ -175,7 +175,7 @@ def gwrite(
     yy = 0
     lastlayer_index = len(document.layers.values()) - 1
 
-    for layer_index, (layer_id, layer) in enumerate(document.layers.items()):
+    for layer_index, (layer_id, layer) in enumerate(sorted(document.layers.items())):
         current_layer = layer  # used by write_template()
 
         write_template(


### PR DESCRIPTION
I was making a vpype script that added in a brush dipping layer between each input SVG layer. However when using gwrite to output to gcode the order of the layers was not as expected (i.e. in order of the vpype layer IDs).

This tiny change fixes that, so layers are now processed in ascending order of the vpype layer IDs.